### PR TITLE
make main adtpro directory default for "ADTPro.properties" and "ADTPr…

### DIFF
--- a/build/adtprobase.sh
+++ b/build/adtprobase.sh
@@ -75,5 +75,4 @@ if [ "$1x" = "headlessx" ]; then
   fi
 fi
 
-cd "$ADTPRO_HOME"/disks
-$HEADLESS"$MY_JAVA_HOME"java -Xms256m -Xmx512m "$TWEAK" $ADTPRO_EXTRA_JAVA_PARMS -cp ../lib/%ADTPRO_VERSION%:../"$RXTXLIB"/../RXTXcomm.jar:../lib/AppleCommander/AppleCommander-%AC_VERSION%.jar org.adtpro.ADTPro $*
+$HEADLESS"$MY_JAVA_HOME"java -Xms256m -Xmx512m "$TWEAK" $ADTPRO_EXTRA_JAVA_PARMS -cp ./lib/%ADTPRO_VERSION%:./"$RXTXLIB"/../RXTXcomm.jar:./lib/AppleCommander/AppleCommander-%AC_VERSION%.jar org.adtpro.ADTPro $*


### PR DESCRIPTION
Changing to "disks" directory causes "ADTPro.properties" and "ADTProTrace.txt" files to be created there. If the intent of this cd was to make the "disks" directory the current working directory for serving disk images, this is unnecessary as the app defaults there anyway.