### PR TITLE
Shell scripts in tar.gz are not executable due to incorrect attribute…

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -147,17 +147,15 @@ all
 		<zip destfile="${builddir}/${distName}.zip"
 			basedir="${builddir}"
 			includes="${distName}/**"/>
-		<tar destfile="${builddir}/${distName}.tar"
+		<tar destfile="${builddir}/${distName}.tar.gz"
+			compression="gzip"
 			basedir="${builddir}"
 			includes="${distName}/**"
-			excludes="${distName}/adtpro.sh">
-			<tarfileset dir="${builddir}" mode="755">
-				<include name="${distName}/adtpro.sh"/>
+			excludes="${distName}/*.sh">
+			<tarfileset dir="${builddir}" filemode="755">
+				<include name="${distName}/*.sh"/>
 			</tarfileset>
 		</tar>
-		<gzip destfile="${builddir}/${distName}.tar.gz"
-			src="${builddir}/${distName}.tar" />
-		<delete file="${builddir}/${distName}.tar" />
 	</target>
 	<target name="dmg" depends="jar" if="isOSX" description="Build OSX DMG Installable Package" >
 		<!-- Build a pretty Mac OSX .app bundle -->


### PR DESCRIPTION
In the build.xml file there is an attempt to set adtpro.sh to file mode 755.  There is no attribute "mode" on the tarfileset type, the attribute should be "filemode" as seen here: https://ant.apache.org/manual/Types/tarfileset.html

Additionally, the AppleCommander shell script file "ac.sh" is also not executable in the resulting tar file.  This change makes both executable and takes out the unnecessary gzip step as compression can be done when the tar is created.