### PR TITLE
Rework Linux librxtxSerial.so selection logic

### DIFF
--- a/build/adtprobase.sh
+++ b/build/adtprobase.sh
@@ -35,9 +35,9 @@ if [ "$OS" = "Linux" ]; then
     RXTXLIB=/usr/lib
   elif [ "$OS_MACHINE" = "armv7l" ]; then
     RXTXLIB="${ADTPRO_HOME}lib/rxtx/%RXTX_VERSION%/arm"
-  elif [ "$OS_ARCH" = "i386" -o "$OS_ARCH" = "i686" ]; then
+  elif [ "$OS_MACHINE" = "i386" -o "$OS_MACHINE" = "i686" ]; then
     RXTXLIB="${ADTPRO_HOME}lib/rxtx/%RXTX_VERSION%/i686-pc-linux-gnu"
-  elif [ "$OS_ARCH" = "x86_64" ]; then
+  elif [ "$OS_MACHINE" = "x86_64" ]; then
     RXTXLIB="${ADTPRO_HOME}lib/rxtx/%RXTX_VERSION%/x86_64-unknown-linux-gnu/librxtxSerial.so"
   else
     echo "Unsupported Linux architecture ${OS_ARCH}."

--- a/build/adtprobase.sh
+++ b/build/adtprobase.sh
@@ -81,6 +81,7 @@ CLASSPATH="${ADTPRO_HOME}lib/ADTPro-2.0.3.jar"
 CLASSPATH+=":/usr/share/java/rxtx/RXTXcomm.jar"
 CLASSPATH+=":${ADTPRO_HOME}lib/AppleCommander/AppleCommander-1.3.5.13-ac.jar"
 
-${HEADLESS}"${MY_JAVA_HOME}"java -Xms256m -Xmx512m "$TWEAK" "${ADTPRO_EXTRA_JAVA_PARMS}" \
+${HEADLESS}"${MY_JAVA_HOME}"java -Xms256m -Xmx512m \
+	"$TWEAK" "${ADTPRO_EXTRA_JAVA_PARMS}" \
 	-cp "${CLASSPATH}" org.adtpro.ADTPro \
 	$*


### PR DESCRIPTION
Hi there,

I reworked a bit of the logic in adtpro.sh to accomplish the following:

* automatically use the system-supplied librxtxSerial.so if it exists.  This allows ADTPro to run on oddball Linux platforms (like Arch Linux aarch64, my particular use case) out-of-the-box.  Previous behavior is preserved.
* use the machine identifier instead of the arch identifier/pi-config to detect Linux platform.  This lets us catch all possible platform cases rather than catch-alling to x86-64.
* re-format variable usage to enhance readability for debugging.

Looks good?

Chris