### PR TITLE
Fix a purely cosmetic bug with printing the slot number ...

### DIFF
--- a/src/client/prodos/ethernet/drive/vedrive_high.asm
+++ b/src/client/prodos/ethernet/drive/vedrive_high.asm
@@ -126,16 +126,18 @@ install_vedrive:
   ldx #>dev_not_found_msg
   jmp error_exit
 
+; calculate and save character to print for slot #
+: adc #'0'
+  pha
+
 ; derive I/O base from slot no.
-: asl
+  asl
   asl
   asl
   asl
   sta io_base
 
 ; print 'uthernet'
-  adc #'0'                      ; carry is clear
-  pha
   lda #<uthernet_msg
   ldx #>uthernet_msg
   jsr print_ascii_as_native


### PR DESCRIPTION
that an Uthernet-II card was found in.
Simple cosmetic fix - does not seem to affect operation in any way.

Currently, the slot number character that gets printed to the screen is calculated after the slot number value ($0n) has been left-shifted/multiplied by 16 ($n0).  This makes the slot number print out on-screen as @/P/`/p/@/P/space instead of 1/2/3/4/5/6/7.  This change moves the calculation of the character to print and the corresponding pha ahead of the multiply operation, so the slot number prints out correctly.
I've been using a VEDRIVE binary built with this change for several days and have not observed any functional problems.