### PR TITLE
Intelligently handle accelerator

### DIFF
--- a/src/client/main.asm
+++ b/src/client/main.asm
@@ -41,6 +41,9 @@ entrypoint:
 	tsx		; Get a handle to the stackptr
 	stx top_stack	; Save it for full pops during aborts
 
+        jsr DETECT_CPU  ; Try to figure out if we're running an accelerator
+        jsr ACCEL_DISABLE ; disable accelerators (if present)
+
 	jsr INIT_SCREEN	; Sets up the screen for behaviors we expect
 	jsr MAKETBL	; Prepare our CRC tables
 	JSR_GET_PREFIX	; Get our current prefix (ProDOS only)
@@ -170,6 +173,7 @@ KQUIT:
 KQUITENTRY:
 	lda #MENU_QUIT
 	jsr HILIGHT_MENU
+        jsr ACCEL_ENABLE
 	jmp QUIT	; Head into OS oblivion
 
 KLEFT:
@@ -354,6 +358,75 @@ BumpA1:
 BumpA1Done:
 	rts
 
+;---------------------------------------------------------
+; ACCEL_* - disable/enable accelerators (if present)
+;---------------------------------------------------------
+ACCEL_DISABLE:
+        lda CPU_TYPE
+        beq AD_EXIT     ; if NMOS, no accel, exit
+        cmp #2          ; if 65816, do UltraWarp
+        beq AD_65816
+        lda #$5a        ; ... otherwise, we're 65C02, do Zip/TransWarp
+        sta $c05a
+        sta $c05a
+        sta $c05a
+        sta $c05a       ; Unlock ZipChip
+ 
+        lda #$00
+        sta $c05a       ; Disable ZipChip       
+        lda #$01
+        sta $C074       ; Disable TransWarp
+        bne AD_EXIT
+
+AD_65816: 
+        lda #$01
+        sta $C05D       ; Slow down UltraWarp
+AD_EXIT:
+        rts
+
+ACCEL_ENABLE:
+        lda CPU_TYPE
+        beq AE_EXIT     ; if NMOS, no accel, exit
+        cmp #2          ; if 65816, do UltraWarp
+        beq AE_65816
+        lda #$00
+        sta $c05b       ; Enable ZipChip
+ 
+        lda #$a5
+        sta $c05a       ; Lock ZipChip
+ 
+        lda #$00        ; Enable TransWarp
+        sta $C074
+        beq AE_EXIT
+
+AE_65816:
+        lda #$01
+        sta $C05C       ; Speed up UltraWarp
+AE_EXIT:
+        rts
+
+;---------------------------------------------------------
+;DETECT_CPU - identify CPU, to try to logic our way through
+;             accelerator detection
+;---------------------------------------------------------
+CPU_TYPE:       .byte 0 ; default to NMOS 6502
+DETECT_CPU:
+.setcpu "6502"
+         lda #0
+.setcpu "65C02"
+         bra :+         ; undocumented two-byte NOP on NMOS
+.setcpu "6502"
+         beq CT_OUT     ; we have an NMOS 6502
+:        inc CPU_TYPE   ; we have a CMOS 65C02/65C816 ...
+.setcpu "65816"
+         lda CPU_TYPE
+         xba            ; exchange B and A (65C816 only)
+         dec            ; A=0 (65C02), A=1 (65C816, via B)
+         xba            ; swap back (again, 65C816 only)
+         inc            ; A=1 (65C02), A=2 (65C816, via B)
+         sta CPU_TYPE
+.setcpu "6502"
+CT_OUT:        rts
 
 ;---------------------------------------------------------
 ; Table of menu highlighting coordinates

--- a/src/client/prodos/ethernet/ethproto.asm
+++ b/src/client/prodos/ethernet/ethproto.asm
@@ -956,31 +956,9 @@ RECEIVE_LOOP_WARM:
 	rts
 
 RECEIVE_LOOP_PAUSE:
-	lda #$5a
-	sta $c05a
-	sta $c05a
-	sta $c05a
-	sta $c05a	; Unlock ZipChip
-
-	lda #$00
-	sta $c05a	; Disable ZipChip	
-
-	lda #$01
-	sta $C074	; Disable TransWarp
-
 PauseValue:
 	lda #$7f
 	jsr DELAY	; Wait!
-
-	lda #$00
-	sta $c05b	; Enable ZipChip
-
-	lda #$a5
-	sta $c05a	; Lock ZipChip
-
-	lda #$00	; Enable TransWarp
-	sta $C074
-
 	jmp RECEIVE_LOOP_WARM
 
 


### PR DESCRIPTION
Per issue #180 , try to logic our way through disabling/enabling CPU accelerators (if present).

This is necessary because the UltraWarp disable-and-crash softswitch at $C05B conflicts with the ZipChip enable-accelerator softswitch (also at $C05B).

Works fine on my enhanced //e, both with and without UltraWarp installed.