### PR TITLE
Fix bare metal go address: `2000G` -> `2003G`

### DIFF
--- a/doc/src/site/apt/bootstrapaudio.apt
+++ b/doc/src/site/apt/bootstrapaudio.apt
@@ -179,7 +179,7 @@ audio cables all the way to making a bootable ADTPro floppy:
 
     [[1]] Once the transfer completes successfully, the kernel of ProDOS is sitting
       at memory location 2000 on your Apple, and needs to be booted.  Back on the Apple,
-      enter the command: <<<2000G>>> from the asterisk prompt.
+      enter the command: <<<2003G>>> from the asterisk prompt.
       This first boot stage should leave your screen looking something like this,
       with the cursor blinking after an asterisk <<<(*)>>> prompt:
 


### PR DESCRIPTION
Updated to match instructions in ADTPro dialog.

Verified with ADTPro 2.1.0 on Apple IIe.
- Using the stated `2000` address causes the ProDOS screen to be shown, immediately followed by 'Relocation/Configuration error' screen.
- Using the corrected '200e` addresses shows the ProDOS screen and then drops into monitor as expected.