### PR TITLE
VDrive: Compute block checksums on the fly

### DIFF
--- a/src/client/prodos/ethernet/drive/ethproto.asm
+++ b/src/client/prodos/ethernet/drive/ethproto.asm
@@ -180,9 +180,12 @@ READBLK:
 	ldx	#$00
 	ldy	#$00
 	stx	SCRN_THROB
+	stx	CHECKSUM
 RDLOOP:
 	lda	(UTILPTR),Y
 	sta	(BUFLO),Y
+	eor	CHECKSUM
+	sta	CHECKSUM
 	iny
 	bne	RDLOOP
 
@@ -200,9 +203,6 @@ RDLOOP:
 	sta	SCRN_THROB
 
 	lda	(UTILPTR),Y	; Checksum
-	pha		; Push checksum for now
-	jsr	CALC_CHECKSUM
-	pla	
 	cmp	CHECKSUM
 	bne	READFAIL
 	lda	#$00
@@ -271,9 +271,12 @@ COMMAND_ENVELOPE:
 ; Copy in the block to write
 	ldx	#$00
 	ldy	#$00
+	stx	CHECKSUM
 WRLOOP:
 	lda	(BUFLO),Y
 	sta	(UTILPTR),Y
+	eor	CHECKSUM
+	sta	CHECKSUM
 	iny
 	bne	WRLOOP
 
@@ -290,7 +293,7 @@ WRLOOP:
 	dec	BUFHI
 	dec	BUFHI	; Bring BUFHI back down to where it belongs
 
-	jsr	CALC_CHECKSUM
+	lda	CHECKSUM
 	jsr	BUFBYTE			; Send the checksum byte
 
 ENV_DONE:

--- a/src/client/prodos/vdrive.asm
+++ b/src/client/prodos/vdrive.asm
@@ -84,24 +84,6 @@ GETSTAT:
 	clc
 	rts
 
-CALC_CHECKSUM:			; Calculate the checksum of the block at BUFLO/BUFHI
-	lda	#$00		; Clean everyone out
-	tax
-	tay
-CC_LOOP:
-	eor	(BUFLO),Y	; Exclusive-or accumulator with what's at (BUFLO),Y
-	sta	CHECKSUM	; Save that tally in CHECKSUM as we go
-	iny
-	bne	CC_LOOP
-	inc	BUFHI		; Y just turned over to zero; bump MSB of buffer
-	inx			; Keep track of trips through the loop - we need two of them
-	cpx	#$02		; The second time X is incremented, this will signfiy twice through the loop
-	bne	CC_LOOP
-
-	dec	BUFHI		; BUFHI got bumped twice, so back it back down
-	dec	BUFHI
-	rts
-
 ;---------------------------------------------------------
 ; abort - stop everything
 ;---------------------------------------------------------


### PR DESCRIPTION
It's faster and smaller.

Two notes:
- I have a very different setup so I could not test this PR. It comes from an equivalent one in my own code that has been tested.
- Because I couldn't build, I didn't do it, but I think that with this change, it is possible to get rid of one of READFAIL/WRITEFAIL for extra compactness.
