### PR TITLE
VSDRIVE/VEDRIVE: Installer should ignore low nibble of unit number in devlst

### DIFF
--- a/src/client/prodos/ethernet/drive/vedriveinstall.asm
+++ b/src/client/prodos/ethernet/drive/vedriveinstall.asm
@@ -48,6 +48,7 @@ scanslots:
 	ldx	DEVCNT
 checkdev:
 	lda	DEVLST,X	; Grab an active device number
+    and #$f0        ; Ignore low nibble as suggested by ProDOS TN#21
 	cmp	VE_SLOT_DEV1	; Slot x, drive 1?
 	beq	scanslots	; Yes, someone already home - go to next slot
 	cmp	VE_SLOT_DEV2	; Slot x, drive 2?

--- a/src/client/prodos/serial/drive/vsdriveinstall_high.asm
+++ b/src/client/prodos/serial/drive/vsdriveinstall_high.asm
@@ -42,6 +42,7 @@ scanslots:
 	ldx	DEVCNT
 checkdev:
 	lda	DEVLST,X	; Grab an active device number
+    and #$f0        ; Ignore low nibble as suggested by ProDOS TN#21
 	cmp	VS_SLOT_DEV1	; Slot x, drive 1?
 	beq	scanslots	; Yes, someone already home - go to next slot
 	cmp	VS_SLOT_DEV2	; Slot x, drive 2?

--- a/src/client/prodos/serial/drive/vsdriveinstall_low.asm
+++ b/src/client/prodos/serial/drive/vsdriveinstall_low.asm
@@ -42,6 +42,7 @@ scanslots:
 	ldx	DEVCNT
 checkdev:
 	lda	DEVLST,X	; Grab an active device number
+    and #$f0        ; Ignore low nibble as suggested by ProDOS TN#21
 	cmp	VS_SLOT_DEV1	; Slot x, drive 1?
 	beq	scanslots	; Yes, someone already home - go to next slot
 	cmp	VS_SLOT_DEV2	; Slot x, drive 2?


### PR DESCRIPTION
VSDRIVE may install the virtual drives to a slot which is used by other drives. The installer looks for an empty slot by scanning the unit numbers in devlst ($BF32-). The routine assumes the low nibbles of the unit numbers in devlst are zeros. But the low nibbles of the unit numbers may contain additional information about the units and may not be zero. For example, the unit number of Aux RAM Disk is $BF.

ProDOS technical note number 21 clearly states that the low nibble should be ignored.

This PR simply masks out the low nibble when the unit number are read.